### PR TITLE
consistent error responses to auth / workspace and bugfixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,11 +13,11 @@ mongoose.connect(`mongodb://${dbConfig.HOST}:${dbConfig.PORT}/${dbConfig.DB}`, {
     useUnifiedTopology: true,
 }).then(() => {
     console.log("Successfully connected to MongoDB.");
-  })
-  .catch(err => {
-    console.error("Failed to connect to MongoDB", err);
-    process.exit();
-});
+})
+    .catch(err => {
+        console.error("Failed to connect to MongoDB", err);
+        process.exit();
+    });
 
 const app = express();
 
@@ -27,6 +27,7 @@ app.use(cors());
 
 app.get('/', (req, res) => response_200(res, 'Server is running'));
 require('./src/routes/auth.routes')(app);
+require('./src/routes/workspace.routes')(app);
 
 app.listen(port, () =>
     console.log(`🚀 Server running on port http://localhost:${port}/`)

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,15 +1,15 @@
 const User = require('../models/user.models')
-const {response_201, response_500} = require('../utils/responseCodes.utils')
+const { response_201, response_500, response_400, response_409 } = require('../utils/responseCodes.utils')
 
 exports.signup = async (req, res) => {
-    const user = new User({
-        name: req.body.name,
-        email: req.body.email,
-        password: req.body.password,
-        username: req.body.username,
-    });
-
     try {
+        const user = new User({
+            name: req.body.name,
+            email: req.body.email,
+            password: req.body.password,
+            username: req.body.username,
+        });
+
         const savedUser = await user.save();
         return response_201(res, 'User created successfully', {
             token: await user.generateToken(),
@@ -18,6 +18,17 @@ exports.signup = async (req, res) => {
             channels: savedUser.channels,
         })
     } catch (err) {
+        if (err.name === "ValidationError") {
+            let messages = [];
+
+            Object.keys(err.errors).forEach((key) => {
+                messages.push(err.errors[key].message);
+            });
+
+            return response_400(res, `Invalid Request: ${messages.join(', ')}`);
+        } else if (err.code == 11000) {
+            return response_409(res, "Invalid Request: username or email already in use")
+        }
         return response_500(res, "Error creating user", err)
     }
 };

--- a/src/controllers/workspace.controller.js
+++ b/src/controllers/workspace.controller.js
@@ -4,18 +4,18 @@ const {
     response_201,
     response_400,
     response_403,
+    response_409,
     response_500
 } = require('../utils/responseCodes.utils')
 
 exports.createWorkspace = async (req, res) => {
-    const workspace = new Workspace({
-        name: req.body.name,
-        description: req.body.description,
-        workspaceId: req.body.workspaceId,
-        createdBy: req.body.userId,
-    });
-
     try {
+        const workspace = new Workspace({
+            name: req.body.name,
+            description: req.body.description,
+            workspaceId: req.body.workspaceId,
+            createdBy: req.body.userId,
+        });
         const savedWorkspace = await workspace.save();
         return response_201(res, 'Workspace created successfully', {
             name: savedWorkspace.name,
@@ -24,15 +24,26 @@ exports.createWorkspace = async (req, res) => {
             id: savedWorkspace._id,
         })
     } catch (err) {
+        if (err.name === "ValidationError") {
+            let messages = [];
+
+            Object.keys(err.errors).forEach((key) => {
+                messages.push(err.errors[key].message);
+            });
+
+            return response_400(res, `Invalid Request: ${messages.join(', ')}`);
+        } else if (err.code == 11000) {
+            return response_409(res, "Invalid Request: Workspace ID already in use")
+        }
         return response_500(res, "Error creating workspace", err)
     }
 }
 
 exports.updateWorkspace = async (req, res) => {
     try {
-        const {name, description, workspaceId, userId} = req.body;
+        const { name, description, workspaceId, userId } = req.body;
 
-        if (!name || !description || !workspaceId || !userId || !req.params.id) {
+        if (!description || !userId || !req.params.id) {
             return response_400(res, "Invalid Request: Missing required fields")
         }
 
@@ -40,20 +51,16 @@ exports.updateWorkspace = async (req, res) => {
         if (!workspace) {
             return response_400(res, "Invalid Request: Workspace not found")
         }
-        if (workspace.createdBy !== userId) {
-            return response_403(res, "Invalid Request: User not authorized to update workspace")
-        }
 
-        const workspaceIDExists = await Workspace.findOne({workspaceId: workspaceId}).exec();
-        if (workspaceIDExists) {
-            return response_400(res, "Invalid Request: workspaceId already in use")
+        if (workspace.createdBy.toString() !== userId) {
+            return response_403(res, "Invalid Request: User not authorized to update workspace")
         }
 
         workspace = await Workspace.findByIdAndUpdate(req.params.id, {
             name: name,
             description: description,
             workspaceId: workspaceId,
-        });
+        }, { runValidators: true });
 
         return response_201(res, 'Workspace Updated Successfully', {
             name: workspace.name,
@@ -62,6 +69,18 @@ exports.updateWorkspace = async (req, res) => {
             id: workspace._id,
         })
     } catch (err) {
+        if (err.name === "ValidationError") {
+            let messages = [];
+
+            Object.keys(err.errors).forEach((key) => {
+                messages.push(err.errors[key].message);
+            });
+
+            return response_400(res, `Invalid Request: ${messages.join(', ')}`);
+        } else if (err.code == 11000) {
+            return response_409(res, "Invalid Request: Workspace ID already in use")
+        }
+        console.log(err);
         return response_500(res, "Error updating workspace", err)
     }
 }
@@ -76,7 +95,7 @@ exports.deleteWorkspace = async (req, res) => {
         if (!workspace) {
             return response_400(res, "Invalid Request: Workspace not found")
         }
-        if (workspace.createdBy !== req.body.userId) {
+        if (workspace.createdBy.toString() !== req.body.userId) {
             return response_403(res, "Invalid Request: User not authorized to delete workspace")
         }
 

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -1,9 +1,5 @@
-const { signupValidation } = require("../middlewares/auth.middleware");
 const { signup } = require("../controllers/auth.controller");
 
 module.exports = app => {
-    app.post('/auth/signup', 
-        [ signupValidation.ensureUniqueEmail, signupValidation.ensureUniqueUsername ],
-        signup
-    );
+    app.post('/auth/signup', signup);
 };

--- a/src/routes/workspace.routes.js
+++ b/src/routes/workspace.routes.js
@@ -1,0 +1,7 @@
+const { createWorkspace, updateWorkspace, deleteWorkspace } = require("../controllers/workspace.controller");
+
+module.exports = app => {
+    app.post('/workspace', createWorkspace);
+    app.put("/workspace/:id", updateWorkspace);
+    app.delete("/workspace/:id", deleteWorkspace);
+};

--- a/src/utils/responseCodes.utils.js
+++ b/src/utils/responseCodes.utils.js
@@ -54,6 +54,14 @@ function response_404(res, message) {
     });
 }
 
+function response_409(res, message) {
+    return res.status(409).json({
+        status: 'error',
+        error: message,
+        message: "Conflict"
+    });
+}
+
 function response_500(res, log_message, err) {
     var message = err != null ? `${log_message}: ${err}` : log_message;
 
@@ -75,5 +83,6 @@ module.exports = {
     response_401,
     response_403,
     response_404,
+    response_409,
     response_500
 };


### PR DESCRIPTION
Issue: #13 

- Added specific error handling in auth and workspace controllers.
- Used conditions inside catch block of controller for "Required field" errors (instead of using Auth middleware), "Other validation" errors, "Unique Constraint" errors (Conflict) etc.
- Added routes for _Workspace_ for testing purposes. Feel free to suggest naming conventions :)
- some bug fixes like `workspace.createdBy.toString() !== req.body.userId`, where _toString_ was initially not there.
- Also I have some confusions regarding the usage of workspaceID in general in this app. Hope the schema is correct? May be I am confused because I don't get the full picture of the application. Please check if we are proceeding in right direction. 

**Cheers**! Lmk if there is anything to be changed in PR.